### PR TITLE
Prevent astro from trying to process the loader script using the `is:inline` directive

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,7 +12,7 @@ const { pageTitle } = Astro.props;
     <link rel="preconnect" href="//sdp.eu.usercentrics.eu">
     <link rel="preload" href="//app.eu.usercentrics.eu/browser-ui/latest/loader.js" as="script">
     <link rel="preload" href="//sdp.eu.usercentrics.eu/latest/uc-block.bundle.js" as="script">
-    <script id="usercentrics-cmp" async data-eu-mode="true" data-settings-id="xxxxxxxxx" src="https://app.eu.usercentrics.eu/browser-ui/latest/loader.js"></script>
+    <script is:inline id="usercentrics-cmp" async data-eu-mode="true" data-settings-id="xxxxxxxxx" src="https://app.eu.usercentrics.eu/browser-ui/latest/loader.js"></script>
     <script type="application/javascript" src="https://sdp.eu.usercentrics.eu/latest/uc-block.bundle.js"></script>
 
     <meta charset="utf-8" />


### PR DESCRIPTION
https://docs.astro.build/en/reference/directives-reference/#isinline

`is:inline` should be applied automatically when your script has any attribute. I will look into why that didn't happen, but this is the workaround for now.